### PR TITLE
[fix] Print to string/buffer for document and nodes

### DIFF
--- a/xml/helper.c
+++ b/xml/helper.c
@@ -4,7 +4,7 @@
 //internal callback functions
 int xml_write_callback(void *ctx, char *buffer, int len) {
 	if (len > 0) {
-		xmlNodeWriteCallback(ctx, buffer, len);
+		xmlNodeWriteCallback(buffer, len);
 	}
   	return len;
 }
@@ -97,17 +97,17 @@ xmlNode* xmlParseFragmentAsDoc(void *doc, void *buffer, int buffer_len, void *ur
 	return tmpRoot;
 }
 
-void xmlSetContent(void *gonode, void *n, void *content) {
+void xmlSetContent(void *n, char *content) {
 	xmlNode *node = (xmlNode*)n;
 	xmlNode *child = node->children;
 	xmlNode *next = NULL;
-	unsigned char *encoded = xmlEncodeSpecialChars(node->doc, content);
+	unsigned char *encoded = xmlEncodeSpecialChars(node->doc, (xmlChar*)content);
 	if (encoded) {
 		while (child) {
 			next = child->next ;
 			xmlUnlinkNode(child);
 			//xmlFreeNode(child);
-			xmlUnlinkNodeCallback(child, gonode);
+			xmlUnlinkNodeCallback(child);
 			child = next ;
 	  	}
 	  	xmlNodeSetContent(node, (xmlChar*)encoded);
@@ -129,14 +129,14 @@ int xmlNodePtrCheck(void *node) {
 	return 1;
 }
 
-int xmlSaveNode(void *wbuffer, void *node, void *encoding, int options) {
+int xmlSaveNode(void *node, void *encoding, int options) {
 	xmlSaveCtxtPtr savectx;
 	const char *c_encoding = (char*)encoding;
 
 	savectx = xmlSaveToIO(
 	      (xmlOutputWriteCallback)xml_write_callback,
 	      (xmlOutputCloseCallback)close_callback,
-	      wbuffer,
+	      NULL,
 	      encoding,
 	      options
 	  );

--- a/xml/helper.h
+++ b/xml/helper.h
@@ -12,10 +12,10 @@
 xmlDoc* xmlParse(void *buffer, int buffer_len, void *url, void *encoding, int options, void *error_buffer, int errror_buffer_len);
 xmlNode* xmlParseFragment(void* doc, void *buffer, int buffer_len, void *url, int options, void *error_buffer, int error_buffer_len);
 xmlNode* xmlParseFragmentAsDoc(void *doc, void *buffer, int buffer_len, void *url, void *encoding, int options, void *error_buffer, int error_buffer_len);
-int xmlSaveNode(void *wbuffer, void *node, void *encoding, int options);
+int xmlSaveNode(void *node, void *encoding, int options);
 void xmlRemoveDefaultNamespace(xmlNode *node);
 
-void xmlSetContent(void *gonode, void *node, void *content);
+void xmlSetContent(void *node, char *content);
 
 xmlDoc* newEmptyXmlDoc();
 xmlElementType getNodeType(xmlNode *node);
@@ -24,8 +24,8 @@ char *htmlDocDumpToString(xmlDoc *doc, int format);
 void xmlFreeChars(char *buffer);
 int xmlUnlinkNodeWithCheck(xmlNode *node);
 int xmlNodePtrCheck(void *node);
-void xmlNodeWriteCallback(void *buffer, void *data, int data_len);
-void xmlUnlinkNodeCallback(void *nodePtr, void *gonodePtr);
+void xmlNodeWriteCallback(void *data, int data_len);
+void xmlUnlinkNodeCallback(void *nodePtr);
 
 typedef struct XmlBufferContext {
 	void *obj;

--- a/xml/node.go
+++ b/xml/node.go
@@ -6,10 +6,12 @@ import "C"
 
 import (
 	"errors"
+	"strconv"
+	"sync"
+	"unsafe"
+
 	. "github.com/merj/gokogiri/util"
 	"github.com/merj/gokogiri/xpath"
-	"strconv"
-	"unsafe"
 )
 
 var (
@@ -88,6 +90,7 @@ type Node interface {
 	LastChild() Node
 	CountChildren() int
 	Attributes() map[string]*AttributeNode
+	AttributeList() []*AttributeNode
 
 	Coerce(interface{}) ([]Node, error)
 
@@ -394,16 +397,23 @@ func (xmlNode *XmlNode) ResetChildren() {
 	}
 }
 
+var (
+	contentNode  *XmlNode
+	contentMutex sync.Mutex
+)
+
 func (xmlNode *XmlNode) SetContent(content interface{}) (err error) {
 	switch data := content.(type) {
 	default:
 		err = ERR_UNDEFINED_SET_CONTENT_PARAM
 	case string:
-		err = xmlNode.SetContent([]byte(data))
+		contentMutex.Lock()
+		contentNode = xmlNode
+		C.xmlSetContent(unsafe.Pointer(xmlNode.Ptr), C.CString(data))
+		contentNode = nil
+		contentMutex.Unlock()
 	case []byte:
-		contentBytes := GetCString(data)
-		contentPtr := unsafe.Pointer(&contentBytes[0])
-		C.xmlSetContent(unsafe.Pointer(xmlNode), unsafe.Pointer(xmlNode.Ptr), contentPtr)
+		err = xmlNode.SetContent(string(data))
 	}
 	return
 }
@@ -460,6 +470,21 @@ func (xmlNode *XmlNode) Replace(data interface{}) (err error) {
 	return
 }
 
+// Return a document-ordered list of attribute nodes.
+func (xmlNode *XmlNode) AttributeList() (attributes []*AttributeNode) {
+	for prop := xmlNode.Ptr.properties; prop != nil; prop = prop.next {
+		if prop.name != nil {
+			attrPtr := unsafe.Pointer(prop)
+			attributeNode := NewNode(attrPtr, xmlNode.Document)
+			if attr, ok := attributeNode.(*AttributeNode); ok {
+				attributes = append(attributes, attr)
+			}
+		}
+	}
+	return
+}
+
+// Return the attribute nodes indexed by name.
 func (xmlNode *XmlNode) Attributes() (attributes map[string]*AttributeNode) {
 	attributes = make(map[string]*AttributeNode)
 	for prop := xmlNode.Ptr.properties; prop != nil; prop = prop.next {
@@ -496,7 +521,7 @@ func (xmlNode *XmlNode) Attribute(name string) (attribute *AttributeNode) {
 }
 
 // Attr returns the value of an attribute.
-
+//
 // If you need to check for the existence of an attribute,
 // use Attribute.
 func (xmlNode *XmlNode) Attr(name string) (val string) {
@@ -517,10 +542,10 @@ func (xmlNode *XmlNode) Attr(name string) (val string) {
 
 // SetAttr sets the value of an attribute. If the attribute is in a namespace,
 // use SetNsAttr instead.
-
+//
 // While this call accepts QNames for the name parameter, it does not check
 // their validity.
-
+//
 // Attributes such as "xml:lang" or "xml:space" are not is a formal namespace
 // and should be set by calling SetAttr with the prefix as part of the name.
 func (xmlNode *XmlNode) SetAttr(name, value string) (val string) {
@@ -539,10 +564,10 @@ func (xmlNode *XmlNode) SetAttr(name, value string) (val string) {
 }
 
 // SetNsAttr sets the value of a namespaced attribute.
-
+//
 // Attributes such as "xml:lang" or "xml:space" are not is a formal namespace
 // and should be set by calling SetAttr with the xml prefix as part of the name.
-
+//
 // The namespace should already be declared and in-scope when SetNsAttr is called.
 // This restriction will be lifted in a future version.
 func (xmlNode *XmlNode) SetNsAttr(href, name, value string) (val string) {
@@ -627,13 +652,13 @@ func (xmlNode *XmlNode) SearchWithVariables(data interface{}, v xpath.VariableSc
 // Evaluate an XPath and return a result of the appropriate type.
 // If a non-nil VariableScope is provided, any variables or functions present
 // in the xpath will be resolved.
-
+//
 // If the result is a nodeset (or the empty nodeset), a nodeset will be returned.
-
+//
 // If the result is a number, a float64 will be returned.
-
+//
 // If the result is a boolean, a bool will be returned.
-
+//
 // In any other cases, the result will be coerced to a string.
 func (xmlNode *XmlNode) EvalXPath(data interface{}, v xpath.VariableScope) (result interface{}, err error) {
 	switch data := data.(type) {
@@ -681,11 +706,11 @@ func (xmlNode *XmlNode) EvalXPath(data interface{}, v xpath.VariableScope) (resu
 // Evaluate an XPath and coerce the result to a boolean according to the
 // XPath rules. In the presence of an error, this function will return false
 // even if the expression cannot actually be evaluated.
-
+//
 // In most cases you are better advised to call EvalXPath; this function is
 // intended for packages that implement XML standards and that are fully aware
 // of the consequences of suppressing a compilation error.
-
+//
 // If a non-nil VariableScope is provided, any variables or registered functions present
 // in the xpath will be resolved.
 func (xmlNode *XmlNode) EvalXPathAsBoolean(data interface{}, v xpath.VariableScope) (result bool) {
@@ -767,21 +792,26 @@ func (xmlNode *XmlNode) serialize(format SerializationOption, encoding, outputBu
 		encodingPtr = nil
 	}
 
-	wbuffer := &WriteBuffer{Node: xmlNode, Buffer: outputBuffer}
-	wbufferPtr := unsafe.Pointer(wbuffer)
+	wbufferMutex.Lock()
+	defer wbufferMutex.Unlock()
+	if outputBuffer == nil {
+		outputBuffer = make([]byte, 0)
+	}
+	wbuffer = &WriteBuffer{Node: xmlNode, Buffer: outputBuffer}
 
-	ret := int(C.xmlSaveNode(wbufferPtr, nodePtr, encodingPtr, C.int(format)))
+	ret := int(C.xmlSaveNode(nodePtr, encodingPtr, C.int(format)))
 	if ret < 0 {
 		panic("output error in xml node serialization: " + strconv.Itoa(ret))
-		return nil, 0
 	}
+	b, o := wbuffer.Buffer, wbuffer.Offset
+	wbuffer = nil
 
-	return wbuffer.Buffer, wbuffer.Offset
+	return b, o
 }
 
 // SerializeWithFormat allows you to control the serialization flags passed to libxml.
 // In most cases ToXml() and ToHtml() provide sensible defaults and should be preferred.
-
+//
 // The format parameter should be a set of SerializationOption constants or'd together.
 // If encoding is nil, the document's output encoding is used - this defaults to UTF-8.
 // If outputBuffer is nil, one will be created for you.
@@ -792,9 +822,9 @@ func (xmlNode *XmlNode) SerializeWithFormat(format SerializationOption, encoding
 // ToXml generates an indented XML document with an XML declaration.
 // It is not guaranteed to be well formed unless xmlNode is an element node,
 // or a document node with only one element child.
-
+//
 // If you need finer control over the formatting, call SerializeWithFormat.
-
+//
 // If encoding is nil, the document's output encoding is used - this defaults to UTF-8.
 // If outputBuffer is nil, one will be created for you.
 func (xmlNode *XmlNode) ToXml(encoding, outputBuffer []byte) ([]byte, int) {
@@ -816,10 +846,10 @@ func (xmlNode *XmlNode) ToUnformattedXml() string {
 
 // ToHtml generates an indented XML document that conforms to HTML 4.0 rules; meaning
 // that some elements may be unclosed or forced to use end tags even when empty.
-
+//
 // If you want to output XHTML, call SerializeWithFormat and enable the XML_SAVE_XHTML
 // flag as part of the format.
-
+//
 // If encoding is nil, the document's output encoding is used - this defaults to UTF-8.
 // If outputBuffer is nil, one will be created for you.
 func (xmlNode *XmlNode) ToHtml(encoding, outputBuffer []byte) ([]byte, int) {
@@ -962,9 +992,14 @@ func (xmlNode *XmlNode) ParseFragment(input, url []byte, options ParseOption) (f
 	return
 }
 
+var (
+	wbuffer      *WriteBuffer
+	wbufferMutex sync.Mutex
+)
+
 //export xmlNodeWriteCallback
-func xmlNodeWriteCallback(wbufferObj unsafe.Pointer, data unsafe.Pointer, data_len C.int) {
-	wbuffer := (*WriteBuffer)(wbufferObj)
+// NOTE: wbufferMutex is locked
+func xmlNodeWriteCallback(data unsafe.Pointer, data_len C.int) {
 	offset := wbuffer.Offset
 
 	if offset > len(wbuffer.Buffer) {
@@ -986,9 +1021,9 @@ func xmlNodeWriteCallback(wbufferObj unsafe.Pointer, data unsafe.Pointer, data_l
 }
 
 //export xmlUnlinkNodeCallback
-func xmlUnlinkNodeCallback(nodePtr unsafe.Pointer, gonodePtr unsafe.Pointer) {
-	xmlNode := (*XmlNode)(gonodePtr)
-	xmlNode.Document.AddUnlinkedNode(nodePtr)
+// NOTE: contentMutex is locked
+func xmlUnlinkNodeCallback(nodePtr unsafe.Pointer) {
+	contentNode.Document.AddUnlinkedNode(nodePtr)
 }
 
 func grow(buffer []byte, n int) (newBuffer []byte) {
@@ -1062,10 +1097,10 @@ func (xmlNode *XmlNode) RemoveDefaultNamespace() {
 }
 
 // Returns a list of all the namespace declarations that exist on this node.
-
+//
 // You can add a namespace declaration by calling DeclareNamespace.
 // Calling SetNamespace will automatically add a declaration if required.
-
+//
 // Calling SetNsAttr does *not* automatically create a declaration. This will
 // fixed in a future version.
 func (xmlNode *XmlNode) DeclaredNamespaces() (result []NamespaceDeclaration) {
@@ -1082,7 +1117,7 @@ func (xmlNode *XmlNode) DeclaredNamespaces() (result []NamespaceDeclaration) {
 }
 
 // Add a namespace declaration to an element.
-
+//
 // This is typically done on the root element or node high up in the tree
 // to avoid duplication. The declaration is not created if the namespace
 // is already declared in this scope with the same prefix.

--- a/xpath/util.go
+++ b/xpath/util.go
@@ -12,21 +12,48 @@ int getXPathObjectType(xmlXPathObject* o);
 */
 import "C"
 
-import "unsafe"
+import (
+	"sync"
+	"unsafe"
+)
 import "reflect"
 import . "github.com/merj/gokogiri/util"
 
+var (
+	contextMap   = make(map[unsafe.Pointer]VariableScope)
+	contextMutex sync.Mutex
+)
+
+func GetScope(ctxt unsafe.Pointer) VariableScope {
+	contextMutex.Lock()
+	context := contextMap[ctxt]
+	contextMutex.Unlock()
+	return context
+}
+
+func SetScope(ctxt unsafe.Pointer, v VariableScope) {
+	contextMutex.Lock()
+	contextMap[ctxt] = v
+	contextMutex.Unlock()
+}
+
+func ClearScope(ctxt unsafe.Pointer) {
+	contextMutex.Lock()
+	delete(contextMap, ctxt)
+	contextMutex.Unlock()
+
+}
+
 //export go_resolve_variables
 func go_resolve_variables(ctxt unsafe.Pointer, name, ns *C.char) (ret C.xmlXPathObjectPtr) {
-	variable := C.GoString(name)
-	namespace := C.GoString(ns)
+	if context := GetScope(ctxt); context != nil {
+		variable := C.GoString(name)
+		namespace := C.GoString(ns)
 
-	context := (*VariableScope)(ctxt)
-	if context != nil {
-		val := (*context).ResolveVariable(variable, namespace)
-		ret = ValueToXPathObject(val)
+		val := context.ResolveVariable(variable, namespace)
+		return ValueToXPathObject(val)
 	}
-	return
+	return nil
 }
 
 // Convert an arbitrary value into a C.xmlXPathObjectPtr
@@ -75,7 +102,8 @@ func ValueToXPathObject(val interface{}) (ret C.xmlXPathObjectPtr) {
 func exec_xpath_function(ctxt C.xmlXPathParserContextPtr, nargs C.int) {
 	function := C.GoString((*C.char)(unsafe.Pointer(ctxt.context.function)))
 	namespace := C.GoString((*C.char)(unsafe.Pointer(ctxt.context.functionURI)))
-	context := (*VariableScope)(ctxt.context.funcLookupData)
+
+	context := GetScope(unsafe.Pointer(ctxt.context))
 
 	argcount := int(nargs)
 	var args []interface{}
@@ -95,9 +123,9 @@ func exec_xpath_function(ctxt C.xmlXPathParserContextPtr, nargs C.int) {
 	// push the result onto the stack
 	// if for some reason we are unable to resolve the
 	// function we push an empty nodeset
-	f := (*context).ResolveFunction(function, namespace)
+	f := context.ResolveFunction(function, namespace)
 	if f != nil {
-		retval := f(*context, args)
+		retval := f(context, args)
 		C.valuePush(ctxt, ValueToXPathObject(retval))
 	} else {
 		ret := C.xmlXPathNewNodeSet(nil)
@@ -110,11 +138,8 @@ func exec_xpath_function(ctxt C.xmlXPathParserContextPtr, nargs C.int) {
 func go_can_resolve_function(ctxt unsafe.Pointer, name, ns *C.char) (ret C.int) {
 	function := C.GoString(name)
 	namespace := C.GoString(ns)
-	context := (*VariableScope)(ctxt)
-	if *context == nil {
-		return C.int(0)
-	}
-	if (*context).IsFunctionRegistered(function, namespace) {
+	context := GetScope(ctxt)
+	if context != nil && context.IsFunctionRegistered(function, namespace) {
 		return C.int(1)
 	}
 	return C.int(0)

--- a/xpath/xpath.go
+++ b/xpath/xpath.go
@@ -69,7 +69,7 @@ type XPathFunction func(context VariableScope, args []interface{}) interface{}
 
 // Types that provide the VariableScope interface know how to resolve
 // XPath variable names into values.
-
+//
 //This interface exist primarily for the benefit of XSLT processors.
 type VariableScope interface {
 	ResolveVariable(string, string) interface{}
@@ -208,8 +208,9 @@ func (xpath *XPath) ResultAsBoolean() (val bool, err error) {
 
 // Add a variable resolver.
 func (xpath *XPath) SetResolver(v VariableScope) {
-	C.set_var_lookup(xpath.ContextPtr, unsafe.Pointer(&v))
-	C.set_function_lookup(xpath.ContextPtr, unsafe.Pointer(&v))
+	SetScope(unsafe.Pointer(xpath.ContextPtr), v)
+	C.set_var_lookup(xpath.ContextPtr, unsafe.Pointer(xpath.ContextPtr))
+	C.set_function_lookup(xpath.ContextPtr, unsafe.Pointer(xpath.ContextPtr))
 }
 
 // SetContextPosition sets the internal values needed to
@@ -223,7 +224,7 @@ func (xpath *XPath) SetContextPosition(position, size int) {
 // GetContextPosition retrieves the internal values used to
 // determine the values of position() and last() for the
 // current context node.
-
+//
 // This allows values to saved and restored during processing
 // of a document.
 func (xpath *XPath) GetContextPosition() (position, size int) {
@@ -234,6 +235,7 @@ func (xpath *XPath) GetContextPosition() (position, size int) {
 
 func (xpath *XPath) Free() {
 	if xpath.ContextPtr != nil {
+		ClearScope(unsafe.Pointer(xpath.ContextPtr))
 		C.xmlXPathFreeContext(xpath.ContextPtr)
 		xpath.ContextPtr = nil
 	}


### PR DESCRIPTION
This fixes the runtime panic when we want to print document or nodes to a string or bytes